### PR TITLE
Added the Windows 10 (UAP) platform to protobuild (pull from MonoGame)

### DIFF
--- a/Protobuild.Internal/BuildResources/GenerateProject.CSharp.xslt
+++ b/Protobuild.Internal/BuildResources/GenerateProject.CSharp.xslt
@@ -17,7 +17,7 @@
   <xsl:variable name="assembly_name">
     <xsl:choose>
       <xsl:when test="$root/Input/Properties/AssemblyName
-	        /Platform[@Name=$root/Input/Generation/Platform]">
+            /Platform[@Name=$root/Input/Generation/Platform]">
         <xsl:value-of select="$root/Input/Properties/AssemblyName/Platform[@Name=$root/Input/Generation/Platform]" />
       </xsl:when>
       <xsl:when test="$root/Input/Properties/AssemblyName">
@@ -55,10 +55,10 @@
       </xsl:when>
       <xsl:when test="user:IsTrueDefault($platform_specific_output_folder)">
         <xsl:value-of select="$root/Input/Generation/Platform" />
-      	<xsl:text>\</xsl:text>
-      	<xsl:value-of select="$platform" />
-      	<xsl:text>\</xsl:text>
-      	<xsl:value-of select="$config" />
+        <xsl:text>\</xsl:text>
+        <xsl:value-of select="$platform" />
+        <xsl:text>\</xsl:text>
+        <xsl:value-of select="$config" />
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$config" />
@@ -122,11 +122,11 @@
             <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
           </xsl:when>
           <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
-			  <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-			  <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
-			  <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
-			  <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
-		  </xsl:when>		
+              <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+              <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+              <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+              <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+          </xsl:when>		
           <xsl:when test="$root/Input/Generation/Platform = 'iOS' or $root/Input/Generation/Platform = 'PSMobile'">
           </xsl:when>
           <xsl:when test="$root/Input/Generation/Platform = 'PCL'">
@@ -178,8 +178,8 @@
       <xsl:attribute name="Condition">
         <xsl:text> '$(Configuration)|$(Platform)' == '</xsl:text>
         <xsl:value-of select="$config" />
-	<xsl:text>|</xsl:text>
-	<xsl:value-of select="$platform" />
+    <xsl:text>|</xsl:text>
+    <xsl:value-of select="$platform" />
         <xsl:text>' </xsl:text>
       </xsl:attribute>
     <xsl:choose>
@@ -194,7 +194,7 @@
       </xsl:when>
       <xsl:otherwise>
         <Optimize>true</Optimize>
-				<DebugType>
+                <DebugType>
           <xsl:choose>
             <xsl:when test="$root/Input/Properties/DebugSymbolsOnRelease">
               <xsl:value-of select="$root/Input/Properties/DebugSymbolsOnRelease" />
@@ -203,7 +203,7 @@
               <xsl:text>none</xsl:text>
             </xsl:otherwise>
           </xsl:choose>
-				</DebugType>
+                </DebugType>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:variable name="platform_path">
@@ -411,9 +411,9 @@
             <xsl:choose>
               <xsl:when test="$root/Input/Properties/IncludeMonoRuntimeOnMac">
                 <IncludeMonoRuntime><xsl:value-of select="$root/Input/Properties/IncludeMonoRuntimeOnMac" /></IncludeMonoRuntime>
-	            <xsl:if test="$root/Input/Properties/MonoMacRuntimeLinkMode">
-	              <LinkMode><xsl:value-of select="$root/Input/Properties/MonoMacRuntimeLinkMode" /></LinkMode>
-	            </xsl:if>
+                <xsl:if test="$root/Input/Properties/MonoMacRuntimeLinkMode">
+                  <LinkMode><xsl:value-of select="$root/Input/Properties/MonoMacRuntimeLinkMode" /></LinkMode>
+                </xsl:if>
               </xsl:when>
               <xsl:otherwise>
                 <IncludeMonoRuntime>False</IncludeMonoRuntime>
@@ -950,10 +950,10 @@
           </xsl:otherwise>
         </xsl:choose>
         <xsl:choose>
-			<xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
-				<FileAlignment>512</FileAlignment>
-			</xsl:when>
-			<xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81'">
+            <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+                <FileAlignment>512</FileAlignment>
+            </xsl:when>
+            <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81'">
             <ProductVersion>8.0.30703</ProductVersion>
           </xsl:when>
           <xsl:otherwise>
@@ -1978,13 +1978,13 @@
           </PropertyGroup>
           <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
         </xsl:when>
-		  <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
-			  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-				  <VisualStudioVersion>14.0</VisualStudioVersion>
-			  </PropertyGroup>
-			  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-		  </xsl:when>
-		  <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+              <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+                  <VisualStudioVersion>14.0</VisualStudioVersion>
+              </PropertyGroup>
+              <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+          </xsl:when>
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
           <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
             <VisualStudioVersion>12.0</VisualStudioVersion>
           </PropertyGroup>

--- a/Protobuild.Internal/BuildResources/GenerateProject.CSharp.xslt
+++ b/Protobuild.Internal/BuildResources/GenerateProject.CSharp.xslt
@@ -121,7 +121,7 @@
             <TargetPlatformVersion>8.1</TargetPlatformVersion>
             <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
           </xsl:when>
-          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
               <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
               <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
               <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
@@ -155,14 +155,14 @@
           <xsl:value-of select="$root/Input/Properties/FrameworkVersions/Profile" />
         </TargetFrameworkProfile>
       </xsl:when>
-      <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP' or $root/Input/Generation/Platform = 'PSMobile' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
+      <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUniversal' or $root/Input/Generation/Platform = 'PSMobile' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
       </xsl:when>
       <xsl:otherwise>
         <TargetFrameworkProfile></TargetFrameworkProfile>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:call-template name="AllowLangVersion" />
-    <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP'">
+    <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUniversal'">
       <DefaultLanguage>en-US</DefaultLanguage>
     </xsl:if>
   </xsl:template>
@@ -273,8 +273,8 @@
               <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
                 <xsl:text>PLATFORM_WINDOWSPHONE81</xsl:text>
               </xsl:when>
-              <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
-                <xsl:text>PLATFORM_WINDOWSUAP</xsl:text>
+              <xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
+                <xsl:text>PLATFORM_WindowsUniversal</xsl:text>
               </xsl:when>
               <xsl:when test="$root/Input/Generation/Platform = 'Web'">
                 <xsl:text>PLATFORM_WEB</xsl:text>
@@ -890,7 +890,7 @@
       </xsl:variable>
 
       <xsl:choose>
-        <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+        <xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
           <xsl:text>14.0</xsl:text>
         </xsl:when>		
         <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
@@ -933,7 +933,7 @@
       DefaultTargets="Build"
       xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="{$ToolsVersion}">
 
-      <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81' or $root/Input/Generation/Platform = 'WindowsUAP' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
+      <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81' or $root/Input/Generation/Platform = 'WindowsUniversal' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
         <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
       </xsl:if>
 
@@ -950,7 +950,7 @@
           </xsl:otherwise>
         </xsl:choose>
         <xsl:choose>
-            <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+            <xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
                 <FileAlignment>512</FileAlignment>
             </xsl:when>
             <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81'">
@@ -1031,7 +1031,7 @@
               <xsl:text>{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</xsl:text>
             </ProjectTypeGuids>
           </xsl:when>
-          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
             <ProjectTypeGuids>
               <xsl:text>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};</xsl:text>
               <xsl:text>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</xsl:text>
@@ -1072,7 +1072,7 @@
                 <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
                   <xsl:text>Library</xsl:text>
                 </xsl:when>
-                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP'">
+                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUniversal'">
                   <xsl:text>AppContainerExe</xsl:text>
                 </xsl:when>
                 <xsl:when test="$root/Input/Generation/Platform = 'Windows'">
@@ -1872,7 +1872,7 @@
                                   /ContentProject[@Name=$include-path]
                                   /Compiled">
               <xsl:choose>
-                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP' or $root/Input/Generation/Platform = 'Windows'">
+                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUniversal' or $root/Input/Generation/Platform = 'Windows'">
                   <Content>
                     <xsl:attribute name="Include">
                       <xsl:value-of
@@ -1978,7 +1978,7 @@
           </PropertyGroup>
           <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
         </xsl:when>
-          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
               <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
                   <VisualStudioVersion>14.0</VisualStudioVersion>
               </PropertyGroup>

--- a/Protobuild.Internal/BuildResources/GenerateProject.CSharp.xslt
+++ b/Protobuild.Internal/BuildResources/GenerateProject.CSharp.xslt
@@ -121,6 +121,12 @@
             <TargetPlatformVersion>8.1</TargetPlatformVersion>
             <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
           </xsl:when>
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+			  <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+			  <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+			  <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+			  <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+		  </xsl:when>		
           <xsl:when test="$root/Input/Generation/Platform = 'iOS' or $root/Input/Generation/Platform = 'PSMobile'">
           </xsl:when>
           <xsl:when test="$root/Input/Generation/Platform = 'PCL'">
@@ -149,14 +155,14 @@
           <xsl:value-of select="$root/Input/Properties/FrameworkVersions/Profile" />
         </TargetFrameworkProfile>
       </xsl:when>
-      <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'PSMobile' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
+      <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP' or $root/Input/Generation/Platform = 'PSMobile' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
       </xsl:when>
       <xsl:otherwise>
         <TargetFrameworkProfile></TargetFrameworkProfile>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:call-template name="AllowLangVersion" />
-    <xsl:if test="$root/Input/Generation/Platform = 'Windows8'">
+    <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP'">
       <DefaultLanguage>en-US</DefaultLanguage>
     </xsl:if>
   </xsl:template>
@@ -266,6 +272,9 @@
               </xsl:when>
               <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
                 <xsl:text>PLATFORM_WINDOWSPHONE81</xsl:text>
+              </xsl:when>
+              <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+                <xsl:text>PLATFORM_WINDOWSUAP</xsl:text>
               </xsl:when>
               <xsl:when test="$root/Input/Generation/Platform = 'Web'">
                 <xsl:text>PLATFORM_WEB</xsl:text>
@@ -881,6 +890,9 @@
       </xsl:variable>
 
       <xsl:choose>
+        <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+          <xsl:text>14.0</xsl:text>
+        </xsl:when>		
         <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
           <xsl:text>12.0</xsl:text>
         </xsl:when>
@@ -921,7 +933,7 @@
       DefaultTargets="Build"
       xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="{$ToolsVersion}">
 
-      <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
+      <xsl:if test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81' or $root/Input/Generation/Platform = 'WindowsUAP' or $root/Input/Generation/Platform = 'PCL' or user:IsTrue($root/Input/Properties/ForcePCL)">
         <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
       </xsl:if>
 
@@ -938,7 +950,10 @@
           </xsl:otherwise>
         </xsl:choose>
         <xsl:choose>
-          <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81'">
+			<xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+				<FileAlignment>512</FileAlignment>
+			</xsl:when>
+			<xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsPhone81'">
             <ProductVersion>8.0.30703</ProductVersion>
           </xsl:when>
           <xsl:otherwise>
@@ -1016,6 +1031,12 @@
               <xsl:text>{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</xsl:text>
             </ProjectTypeGuids>
           </xsl:when>
+          <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+            <ProjectTypeGuids>
+              <xsl:text>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};</xsl:text>
+              <xsl:text>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</xsl:text>
+            </ProjectTypeGuids>
+          </xsl:when>	
           <xsl:otherwise>
           </xsl:otherwise>
         </xsl:choose>
@@ -1051,7 +1072,7 @@
                 <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
                   <xsl:text>Library</xsl:text>
                 </xsl:when>
-                <xsl:when test="$root/Input/Generation/Platform = 'Windows8'">
+                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP'">
                   <xsl:text>AppContainerExe</xsl:text>
                 </xsl:when>
                 <xsl:when test="$root/Input/Generation/Platform = 'Windows'">
@@ -1851,7 +1872,7 @@
                                   /ContentProject[@Name=$include-path]
                                   /Compiled">
               <xsl:choose>
-                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'Windows'">
+                <xsl:when test="$root/Input/Generation/Platform = 'Windows8' or $root/Input/Generation/Platform = 'WindowsUAP' or $root/Input/Generation/Platform = 'Windows'">
                   <Content>
                     <xsl:attribute name="Include">
                       <xsl:value-of
@@ -1957,7 +1978,13 @@
           </PropertyGroup>
           <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
         </xsl:when>
-        <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
+		  <xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+			  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+				  <VisualStudioVersion>14.0</VisualStudioVersion>
+			  </PropertyGroup>
+			  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+		  </xsl:when>
+		  <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
           <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
             <VisualStudioVersion>12.0</VisualStudioVersion>
           </PropertyGroup>

--- a/Protobuild.Internal/BuildResources/GenerateSolution.xslt
+++ b/Protobuild.Internal/BuildResources/GenerateSolution.xslt
@@ -17,7 +17,14 @@
 
   <xsl:template match="/">
     <xsl:choose>
-      <xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
+		<xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+			<xsl:text>Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
+MinimumVisualStudioVersion = 10.0.40219.1
+</xsl:text>
+		</xsl:when>		
+		<xsl:when test="$root/Input/Generation/Platform = 'WindowsPhone81'">
 <xsl:text>Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 </xsl:text>

--- a/Protobuild.Internal/BuildResources/GenerateSolution.xslt
+++ b/Protobuild.Internal/BuildResources/GenerateSolution.xslt
@@ -17,7 +17,7 @@
 
   <xsl:template match="/">
     <xsl:choose>
-		<xsl:when test="$root/Input/Generation/Platform = 'WindowsUAP'">
+		<xsl:when test="$root/Input/Generation/Platform = 'WindowsUniversal'">
 			<xsl:text>Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.22609.0


### PR DESCRIPTION
As pre request here:
https://github.com/mono/MonoGame/issues/3405#issuecomment-156738010

Created a PR to add Windows 10 (UAP) platform support to ProtoBuild .xslt's

(Still not sure about naming them UAP as the proper Windows 10 definition is UWP, but that is the current standard used in MG presently)